### PR TITLE
Replace oob default redirect_uri with localhost.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -42,7 +42,7 @@ $build_sc->new(
   create_makefile_pl => "traditional",
   dist_abstract      => "Google Ads API Client Library for Perl",
   dist_name          => "Google-Ads-GoogleAds-Client",
-  dist_version       => "13.1.0",
+  dist_version       => "13.1.1",
   requires           => {
     "Class::Load"                  => 0,
     "Class::Std::Fast"             => 0,

--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+13.1.1 - 2022-09-15
+- Updated the default redirect_uri, used in generate_user_credentials example,
+  to remove OOB redirect. See relevant blog post:
+  https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html.
+
 13.1.0 - 2022-08-22
 - Added support for Google Ads API v11_1.
 - Added code examples: generate_historical_metrics.

--- a/lib/Google/Ads/GoogleAds/Client.pm
+++ b/lib/Google/Ads/GoogleAds/Client.pm
@@ -21,7 +21,7 @@ package Google::Ads::GoogleAds::Client;
 use strict;
 use warnings;
 use version;
-our $VERSION = qv("13.1.0");
+our $VERSION = qv("13.1.1");
 
 use Google::Ads::GoogleAds::OAuth2ApplicationsHandler;
 use Google::Ads::GoogleAds::OAuth2ServiceAccountsHandler;

--- a/lib/Google/Ads/GoogleAds/Common/OAuthApplicationsHandlerInterface.pm
+++ b/lib/Google/Ads/GoogleAds/Common/OAuthApplicationsHandlerInterface.pm
@@ -1,4 +1,4 @@
-# Copyright 2019, Google LLC
+# Copyright 2022, Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,14 +74,13 @@ Method to obtain/update an access token.
 
 =item *
 
-The authorization code returned to your callback URL or printed out if using 'oob'
-special callback URL.
+The authorization code returned to your callback URL.
 
 =back
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2019 Google LLC
+Copyright 2022 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Google/Ads/GoogleAds/Constants.pm
+++ b/lib/Google/Ads/GoogleAds/Constants.pm
@@ -24,7 +24,7 @@ use File::HomeDir;
 use File::Spec::Functions;
 
 # Main version number that the rest of the modules pick up off of.
-our $VERSION = qv("13.1.0");
+our $VERSION = qv("13.1.1");
 
 use constant DEFAULT_PROPERTIES_FILE =>
   catfile(File::HomeDir->my_home, "googleads.properties");

--- a/lib/Google/Ads/GoogleAds/OAuth2ApplicationsHandler.pm
+++ b/lib/Google/Ads/GoogleAds/OAuth2ApplicationsHandler.pm
@@ -1,4 +1,4 @@
-# Copyright 2019, Google LLC
+# Copyright 2022, Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -232,9 +232,10 @@ consent.
 
 =head2 redirect_uri
 
-Redirect URI as set for you in the Google APIs console, to which the
-authorization flow will callback with the authorization code. Defaults to
-urn:ietf:wg:oauth:2.0:oob for the desktop applications flow.
+Redirect URI to which the authorization flow will callback with the authorization
+code. If using Web flow, the redirect URI must match exactly what’s configured in
+GCP for the OAuth client. If using Desktop flow, the redirect must be a localhost
+URL and is not explicitly set in GCP. The default is http://127.0.0.1.
 
 =head2 access_token
 
@@ -332,7 +333,7 @@ The encoded URL string of OAuth2 scopes separated by pluses.
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2019 Google LLC
+Copyright 2022 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Google/Ads/GoogleAds/OAuth2ApplicationsHandler.pm
+++ b/lib/Google/Ads/GoogleAds/OAuth2ApplicationsHandler.pm
@@ -35,7 +35,7 @@ my %access_type_of : ATTR(:name<access_type> :default<offline>);
 my %prompt_of : ATTR(:name<prompt> :default<consent>);
 my %refresh_token_of : ATTR(:name<refresh_token> :default<>);
 my %redirect_uri_of :
-  ATTR(:name<redirect_uri> :default<urn:ietf:wg:oauth:2.0:oob>);
+  ATTR(:name<redirect_uri> :default<http://127.0.0.1>);
 my %additional_scopes_of : ATTR(:name<additional_scopes> :default<>);
 
 # Methods from Google::Ads::GoogleAds::Common::AuthHandlerInterface.

--- a/t/013_OAuth2ApplicationsHandler.t
+++ b/t/013_OAuth2ApplicationsHandler.t
@@ -47,7 +47,7 @@ ok(!$handler->is_auth_enabled(), "The auth handler is not enabled yet.");
 is($handler->get_access_type(), "offline", "Default value of access_type.");
 is($handler->get_prompt(),      "consent", "Default value of prompt.");
 is($handler->get_redirect_uri(),
-  "urn:ietf:wg:oauth:2.0:oob", "Default value of redirect_uri.");
+  "http://127.0.0.1", "Default value of redirect_uri.");
 is($handler->get_additional_scopes(),
   undef, "Default value of additional_scopes.");
 is_deeply(


### PR DESCRIPTION
Updated the default redirect_uri, used in generate_user_credentials example, to remove OOB redirect. See relevant blog post: https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html.

Fixes #88