### PR TITLE
Fix typo in add_smart_campaign.pl

### DIFF
--- a/examples/advanced_operations/add_smart_campaign.pl
+++ b/examples/advanced_operations/add_smart_campaign.pl
@@ -261,7 +261,7 @@ sub _get_keyword_text_auto_completions {
   # Map the keyword theme constants to KeywordTheme instances for consistency
   # with the response from SmartCampaignSuggestService.SuggestKeywordThemes.
   my $keyword_themes = [];
-  foreach my $keyword_theme_constant (@{response->{keywordThemeConstants}}) {
+  foreach my $keyword_theme_constant (@{$response->{keywordThemeConstants}}) {
     push @$keyword_themes,
       Google::Ads::GoogleAds::V12::Services::SmartCampaignSuggestService::KeywordTheme
       ->new({


### PR DESCRIPTION
Missing $ causing error `Can't use bareword (response) as a HASH ref while strict refs in use`