### PR TITLE
Added: example to exclude IP addresses from the campaign.

### DIFF
--- a/examples/campaign_management/update_campaign_criterion_ip_block.pl
+++ b/examples/campaign_management/update_campaign_criterion_ip_block.pl
@@ -75,6 +75,9 @@ sub update_campaign_criterion_ip_block {
       Google::Ads::GoogleAds::V12::Services::CampaignCriterionService::CampaignCriterionOperation
       ->new({
         create => $campaign_criterion,
+
+        # for removing the IP from the campaign criterion
+        # 'remove' => <ip_resource_name>,
       },
       );
     push @{$operations}, $campaign_criterion_operation;

--- a/examples/campaign_management/update_campaign_criterion_ip_block.pl
+++ b/examples/campaign_management/update_campaign_criterion_ip_block.pl
@@ -1,0 +1,146 @@
+#!/usr/bin/perl -w
+#
+# Copyright 2019, Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This example demonstrates how to add a campaign-level bid modifier for call
+# interactions.
+
+use strict;
+use warnings;
+use utf8;
+
+use FindBin qw($Bin);
+use lib "$Bin/../../lib";
+use Google::Ads::GoogleAds::Client;
+use Google::Ads::GoogleAds::Utils::GoogleAdsHelper;
+use Google::Ads::GoogleAds::Utils::FieldMasks;
+use Google::Ads::GoogleAds::V12::Resources::CampaignCriterion;
+use
+  Google::Ads::GoogleAds::V12::Services::CampaignCriterionService::CampaignCriterionOperation;
+use Google::Ads::GoogleAds::V12::Utils::ResourceNames;
+
+use Getopt::Long qw(:config auto_help);
+use Pod::Usage;
+use Cwd qw(abs_path);
+
+# The following parameter(s) should be provided to run the example. You can
+# either specify these by changing the INSERT_XXX_ID_HERE values below, or on
+# the command line.
+#
+# Parameters passed on the command line will override any parameters set in
+# code.
+#
+# Running the example with -h will print the command line usage.
+my $customer_id  = "INSERT_CUSTOMER_ID_HERE";
+my $campaign_id  = "INSERT_CAMPAIGN_ID_HERE";
+my $CRITERION_ID = "27";                        # ip_block
+my $ip_block;
+
+sub update_campaign_criterion_ip_block {
+  my ($api_client, $customer_id, $campaign_id, $CRITERION_ID, $ip_block) = @_;
+
+  my $resource_name =
+    Google::Ads::GoogleAds::V12::Utils::ResourceNames::campaign_criterion(
+    $customer_id, $campaign_id, $CRITERION_ID,);
+
+  my $operations;
+  foreach my $ip (split(',', $ip_block)) {
+
+    # Create a campaign criterion with the specified resource name (ip_block) and
+    # IP address which needs to be excluded.
+    my $campaign_criterion =
+      Google::Ads::GoogleAds::V12::Resources::CampaignCriterion->new({
+        resourceName => $resource_name,
+        negative     => 'True',
+        ipBlock      => {
+          ip_address => $ip,
+        },
+
+      });
+
+    # Create the campaign criterion operation.
+    my $campaign_criterion_operation =
+      Google::Ads::GoogleAds::V12::Services::CampaignCriterionService::CampaignCriterionOperation
+      ->new({
+        create => $campaign_criterion,
+      },
+      );
+    push @{$operations}, $campaign_criterion_operation;
+  }
+
+  # Issue a mutate request to update the excluded IPs of campaign criterion.
+  my $campaign_criteria_response =
+    $api_client->CampaignCriterionService()->mutate({
+      customerId => $customer_id,
+      operations => $operations,
+    });
+
+  foreach my $response (@{$campaign_criteria_response->{results}}) {
+
+    # Print the resource name (ip_block) of the updated campaign criterion.
+    printf "Campaign criterion with resource name '%s' was modified.\n",
+      $response->{resourceName};
+  }
+
+  return 1;
+}
+
+# Don't run the example if the file is being included.
+if (abs_path($0) ne abs_path(__FILE__)) {
+  return 1;
+}
+
+# Get Google Ads Client, credentials will be read from ~/googleads.properties.
+my $api_client = Google::Ads::GoogleAds::Client->new();
+
+# By default examples are set to die on any server returned fault.
+$api_client->set_die_on_faults(1);
+
+# Parameters passed on the command line will override any parameters set in code.
+GetOptions(
+  "customer_id=s" => \$customer_id,
+  "campaign_id=i" => \$campaign_id,
+  "ip_block=s"    => \$ip_block,
+);
+
+# Print the help message if the parameters are not initialized in the code nor
+# in the command line.
+pod2usage(2)
+  if not check_params($customer_id, $campaign_id, $ip_block);
+
+# Call the example.
+update_campaign_criterion_ip_block($api_client, $customer_id =~ s/-//gr,
+  $campaign_id, $ip_block);
+
+=pod
+
+=head1 NAME
+
+update_campaign_criterion_ip_block
+
+=head1 DESCRIPTION
+
+This example add given list of IPs to exclude for the given campaign.
+
+=head1 SYNOPSIS
+
+update_campaign_criterion_ip_block.pl [options]
+
+    -help                       Show the help message.
+    -customer_id                The Google Ads customer ID.
+    -campaign_id                The campaign ID.
+    -ip_block                   comma separated IPs to block.
+
+=cut

--- a/examples/campaign_management/update_campaign_criterion_ip_block.pl
+++ b/examples/campaign_management/update_campaign_criterion_ip_block.pl
@@ -45,7 +45,7 @@ use Cwd qw(abs_path);
 my $customer_id  = "INSERT_CUSTOMER_ID_HERE";
 my $campaign_id  = "INSERT_CAMPAIGN_ID_HERE";
 
-# ip_block_criterion_id
+# ip_block criterion ID
 my $CRITERION_ID = "27";
 my $ip_block;
 
@@ -58,7 +58,6 @@ sub update_campaign_criterion_ip_block {
 
   my $operations;
   foreach my $ip (split(',', $ip_block)) {
-
     # Create a campaign criterion with the specified resource name (ip_block) and
     # IP address which needs to be excluded.
     my $campaign_criterion =
@@ -68,7 +67,6 @@ sub update_campaign_criterion_ip_block {
         ipBlock      => {
           ip_address => $ip,
         },
-
       });
 
     # Create the campaign criterion operation.
@@ -76,14 +74,12 @@ sub update_campaign_criterion_ip_block {
       Google::Ads::GoogleAds::V13::Services::CampaignCriterionService::CampaignCriterionOperation
       ->new({
         create => $campaign_criterion,
-
         # To remove the IP block campaign criterion, use:
         # remove => <campaign_criterion_resource_name>
-      },
-      );
+      });
+
     push @{$operations}, $campaign_criterion_operation;
   }
-
   # Issue a mutate request to create the campaign criteria for the IP addresses to exclude.
   my $campaign_criteria_response =
     $api_client->CampaignCriterionService()->mutate({
@@ -92,7 +88,6 @@ sub update_campaign_criterion_ip_block {
     });
 
   foreach my $response (@{$campaign_criteria_response->{results}}) {
-
     # Print the resource name (ip_block) of the updated campaign criterion.
     printf "Campaign criterion with resource name '%s' was modified.\n",
       $response->{resourceName};

--- a/examples/campaign_management/update_campaign_criterion_ip_block.pl
+++ b/examples/campaign_management/update_campaign_criterion_ip_block.pl
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This example demonstrates how to add a campaign-level bid modifier for call
-# interactions.
+# This example demonstrates how to add a campaign-level IP exclusion.
 
 use strict;
 use warnings;
@@ -26,10 +25,10 @@ use lib "$Bin/../../lib";
 use Google::Ads::GoogleAds::Client;
 use Google::Ads::GoogleAds::Utils::GoogleAdsHelper;
 use Google::Ads::GoogleAds::Utils::FieldMasks;
-use Google::Ads::GoogleAds::V12::Resources::CampaignCriterion;
+use Google::Ads::GoogleAds::V13::Resources::CampaignCriterion;
 use
-  Google::Ads::GoogleAds::V12::Services::CampaignCriterionService::CampaignCriterionOperation;
-use Google::Ads::GoogleAds::V12::Utils::ResourceNames;
+  Google::Ads::GoogleAds::V13::Services::CampaignCriterionService::CampaignCriterionOperation;
+use Google::Ads::GoogleAds::V13::Utils::ResourceNames;
 
 use Getopt::Long qw(:config auto_help);
 use Pod::Usage;
@@ -45,14 +44,16 @@ use Cwd qw(abs_path);
 # Running the example with -h will print the command line usage.
 my $customer_id  = "INSERT_CUSTOMER_ID_HERE";
 my $campaign_id  = "INSERT_CAMPAIGN_ID_HERE";
-my $CRITERION_ID = "27";                        # ip_block
+
+# ip_block_criterion_id
+my $CRITERION_ID = "27";
 my $ip_block;
 
 sub update_campaign_criterion_ip_block {
-  my ($api_client, $customer_id, $campaign_id, $CRITERION_ID, $ip_block) = @_;
+  my ($api_client, $customer_id, $campaign_id, $ip_block) = @_;
 
   my $resource_name =
-    Google::Ads::GoogleAds::V12::Utils::ResourceNames::campaign_criterion(
+    Google::Ads::GoogleAds::V13::Utils::ResourceNames::campaign_criterion(
     $customer_id, $campaign_id, $CRITERION_ID,);
 
   my $operations;
@@ -61,7 +62,7 @@ sub update_campaign_criterion_ip_block {
     # Create a campaign criterion with the specified resource name (ip_block) and
     # IP address which needs to be excluded.
     my $campaign_criterion =
-      Google::Ads::GoogleAds::V12::Resources::CampaignCriterion->new({
+      Google::Ads::GoogleAds::V13::Resources::CampaignCriterion->new({
         resourceName => $resource_name,
         negative     => 'True',
         ipBlock      => {
@@ -72,18 +73,18 @@ sub update_campaign_criterion_ip_block {
 
     # Create the campaign criterion operation.
     my $campaign_criterion_operation =
-      Google::Ads::GoogleAds::V12::Services::CampaignCriterionService::CampaignCriterionOperation
+      Google::Ads::GoogleAds::V13::Services::CampaignCriterionService::CampaignCriterionOperation
       ->new({
         create => $campaign_criterion,
 
-        # for removing the IP from the campaign criterion
-        # 'remove' => <ip_resource_name>,
+        # To remove the IP block campaign criterion, use:
+        # remove => <campaign_criterion_resource_name>
       },
       );
     push @{$operations}, $campaign_criterion_operation;
   }
 
-  # Issue a mutate request to update the excluded IPs of campaign criterion.
+  # Issue a mutate request to create the campaign criteria for the IP addresses to exclude.
   my $campaign_criteria_response =
     $api_client->CampaignCriterionService()->mutate({
       customerId => $customer_id,
@@ -144,6 +145,6 @@ update_campaign_criterion_ip_block.pl [options]
     -help                       Show the help message.
     -customer_id                The Google Ads customer ID.
     -campaign_id                The campaign ID.
-    -ip_block                   comma separated IPs to block.
+    -ip_block                   Comma separated IPs to block.
 
 =cut


### PR DESCRIPTION
Fix: https://github.com/googleads/google-ads-perl/issues/97 Added: example to exclude IP addresses from the campaign by updating `campaign_criterion`.
