### PR TITLE
Remove the usage of eCPC bidding because of its deprecation

### DIFF
--- a/examples/shopping_ads/add_shopping_product_ad.pl
+++ b/examples/shopping_ads/add_shopping_product_ad.pl
@@ -165,12 +165,16 @@ sub add_standard_shopping_campaign {
       # the ads from immediately serving. Set to ENABLED once you've added
       # targeting and the ads are ready to serve.
       status => Google::Ads::GoogleAds::V15::Enums::CampaignStatusEnum::PAUSED,
-      # Set the bidding strategy to Manual CPC (with eCPC enabled).
+      # Sets the bidding strategy to Manual CPC (with eCPC disabled). eCPC for
+      # standard Shopping campaigns is deprecated. If eCPC is set to true,
+      # Google Ads ignores the setting and behaves as if the setting was false.
+      # See this blog post for more information:
+      # https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html
       # Recommendation: Use one of the automated bidding strategies for shopping
       # campaigns to help you optimize your advertising spend. More information
       # can be found here: https://support.google.com/google-ads/answer/6309029.
       manualCpc => Google::Ads::GoogleAds::V15::Common::ManualCpc->new(
-        {enhancedCpcEnabled => "true"}
+        {enhancedCpcEnabled => "false"}
       ),
       # Set the budget.
       campaignBudget => $budget_resource_name

--- a/examples/shopping_ads/add_shopping_product_ad.pl
+++ b/examples/shopping_ads/add_shopping_product_ad.pl
@@ -165,7 +165,7 @@ sub add_standard_shopping_campaign {
       # the ads from immediately serving. Set to ENABLED once you've added
       # targeting and the ads are ready to serve.
       status => Google::Ads::GoogleAds::V15::Enums::CampaignStatusEnum::PAUSED,
-      # Sets the bidding strategy to Manual CPC (with eCPC disabled). eCPC for
+      # Set the bidding strategy to Manual CPC (with eCPC disabled). eCPC for
       # standard Shopping campaigns is deprecated. If eCPC is set to true,
       # Google Ads ignores the setting and behaves as if the setting was false.
       # See this blog post for more information:


### PR DESCRIPTION
To align with the [code example change](https://github.com/googleads/google-ads-java/pull/742) requested for the Java client library.

As seen in this [blog announcement](https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html), any Shopping campaigns using Enhanced cost-per-click (eCPC) will behave as if they are using Manual cost-per-click (CPC) bidding.

Because of the change, I'm updating the examples related to the announcement to reflect the new recommended practice.