### PR TITLE
Remove the reference for setting Customer Match membership to no expiration

### DIFF
--- a/examples/remarketing/add_customer_match_user_list.pl
+++ b/examples/remarketing/add_customer_match_user_list.pl
@@ -107,8 +107,8 @@ sub create_customer_match_user_list {
       name        => "Customer Match list #" . uniqid(),
       description =>
         "A list of customers that originated from email and physical addresses",
-      # Customer Match user lists can use a membership life span of 10000 to
-      # indicate unlimited; otherwise normal values apply.
+      # Membership life span must be between 0 and 540 days inclusive. See:
+      # https://developers.google.com/google-ads/api/reference/rpc/latest/UserList#membership_life_span
       # Set the membership life span to 30 days.
       membershipLifeSpan => 30,
       # Set the upload key type to indicate the type of identifier that will be


### PR DESCRIPTION
As announced in [this blog post](https://ads-developers.googleblog.com/2025/02/update-to-customer-match-membership.html), we will soon disallow setting `membership_life_span` to no expiration.

Updated the comment to reflect this change.