### PR TITLE
Enhance proxy setup in OAuth2BaseHandler

### DIFF
--- a/lib/Google/Ads/GoogleAds/Common/OAuth2BaseHandler.pm
+++ b/lib/Google/Ads/GoogleAds/Common/OAuth2BaseHandler.pm
@@ -54,11 +54,14 @@ sub initialize : CUMULATIVE(BASE FIRST) {
   $access_token_of{$ident} = $properties->{accessToken}
     || $access_token_of{$ident};
 
-  # Set up proxy for __lwp_agent.
+  # Set up proxy for __lwp_agent. Load environment variables (e.g., NO_PROXY) first.
+  $__lwp_agent_of{$ident}->env_proxy;
+
+  # Override with explicit proxy if configured in the API client.
   my $proxy = $api_client->get_proxy();
-  $proxy
-    ? $__lwp_agent_of{$ident}->proxy(['http', 'https'], $proxy)
-    : $__lwp_agent_of{$ident}->env_proxy;
+  if ($proxy) {
+    $__lwp_agent_of{$ident}->proxy(['http', 'https'], $proxy);
+  }
 }
 
 sub prepare_request {


### PR DESCRIPTION
This change updates the proxy initialization logic in OAuth2BaseHandler.pm to unconditionally load environment proxy settings so that system bypass rules like `NO_PROXY` are properly respected. 

Previously, the authentication handler used a ternary operator that completely skipped loading the environment configuration if an explicit proxy was provided by the API client.